### PR TITLE
build: fixing dependencies version for MSRV="1.75.0"

### DIFF
--- a/tsubakuro-rust-core/Cargo.lock
+++ b/tsubakuro-rust-core/Cargo.lock
@@ -995,9 +995,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "socket2"
@@ -1150,6 +1150,7 @@ dependencies = [
  "async-trait",
  "bigdecimal",
  "chrono",
+ "litemap",
  "log",
  "prost",
  "prost-build",
@@ -1157,6 +1158,8 @@ dependencies = [
  "time",
  "tokio",
  "url",
+ "zerofrom",
+ "zerofrom-derive",
 ]
 
 [[package]]

--- a/tsubakuro-rust-core/Cargo.toml
+++ b/tsubakuro-rust-core/Cargo.toml
@@ -22,6 +22,9 @@ rust_decimal = { version = "1.36.0", optional = true }
 time =  { version = "0.3.37", optional = true }
 tokio = { version = "1.42.0", features = ["rt-multi-thread", "io-util", "net", "sync", "time"] }
 url = "2.5.4"
+litemap = "=0.7.4"
+zerofrom = "=0.1.5"
+zerofrom-derive = "=0.1.5"
 
 [build-dependencies]
 prost-build = "0.13.3"

--- a/tsubakuro-rust-dbtest/Cargo.lock
+++ b/tsubakuro-rust-dbtest/Cargo.lock
@@ -1097,9 +1097,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "socket2"
@@ -1265,6 +1265,7 @@ dependencies = [
  "async-trait",
  "bigdecimal",
  "chrono",
+ "litemap",
  "log",
  "prost",
  "prost-build",
@@ -1272,6 +1273,8 @@ dependencies = [
  "time",
  "tokio",
  "url",
+ "zerofrom",
+ "zerofrom-derive",
 ]
 
 [[package]]

--- a/tsubakuro-rust-ffi/Cargo.lock
+++ b/tsubakuro-rust-ffi/Cargo.lock
@@ -631,18 +631,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -651,9 +651,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "socket2"
@@ -737,11 +737,14 @@ name = "tsubakuro-rust-core"
 version = "0.1.0-beta.1"
 dependencies = [
  "async-trait",
+ "litemap",
  "log",
  "prost",
  "prost-build",
  "tokio",
  "url",
+ "zerofrom",
+ "zerofrom-derive",
 ]
 
 [[package]]


### PR DESCRIPTION
Fix dependencies version for latest litemap and zerofrom requires rust 1.81.0.