### PR TITLE
build: change maven snapshot repository to central portal

### DIFF
--- a/tsubakuro-rust-java/build.gradle
+++ b/tsubakuro-rust-java/build.gradle
@@ -11,7 +11,7 @@ version = '0.3.0'
 repositories {
     mavenCentral()
     maven {
-        url 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
+        url 'https://central.sonatype.com/repository/maven-snapshots/'
         content {
             includeGroupByRegex 'com\\.tsurugidb.*'
         }


### PR DESCRIPTION
This pull request changes the URL for the Maven snapshots repository for migrating OSSRH to Central Portal.